### PR TITLE
Add built-in support for HF transformers models

### DIFF
--- a/weasel/datamodules/transformers_datamodule.py
+++ b/weasel/datamodules/transformers_datamodule.py
@@ -1,0 +1,196 @@
+from typing import Dict, List, Optional, Union, Tuple
+
+import numpy as np
+import torch
+from torch.utils.data import DataLoader
+
+from weasel.datamodules.base_datamodule import AbstractWeaselDataModule
+from weasel.datamodules.dataset_classes import (
+    AbstractWeaselDataset,
+    AbstractDownstreamDataset,
+)
+
+
+class TransformersTrainDataset(AbstractWeaselDataset):
+    """Train dataset for the TransformersDataModule.
+
+    Args:
+        L: The weak label matrix.
+        inputs: A list of output dictionaries of a `transformers.PreTrainedTokenizerBase`.
+    """
+
+    def __init__(self, L: Union[np.ndarray, torch.Tensor], inputs: List[Dict]):
+        super().__init__(L, None)
+        self.inputs = inputs
+
+        if self.L.shape[0] != len(self.inputs):
+            raise ValueError("L and inputs have different number of samples")
+
+    def __getitem__(self, item) -> Tuple[torch.Tensor, Dict]:
+        return self.L[item], self.inputs[item]
+
+
+class TransformersTestDataset(AbstractDownstreamDataset):
+    """Test/Validation dataset for the TransformersDataModule.
+
+    Args:
+        inputs: A list of output dictionaries of a `transformers.PreTrainedTokenizerBase`.
+        Y: Target labels \in {0, .., C-1}^N
+    """
+
+    def __init__(self, inputs: List[Dict], Y: Union[np.ndarray, torch.Tensor]):
+        super().__init__(None, Y)
+        self.inputs = inputs
+
+        if len(self.Y) != len(self.inputs):
+            raise ValueError("inputs and Y have different number of samples")
+
+    def __getitem__(self, item) -> Tuple[Dict, torch.Tensor]:
+        return self.inputs[item], self.Y[item]
+
+
+class TransformersCollator:
+    """Collator for the TransformersDataModule.
+
+    Args:
+        tokenizer: The tokenizer instance used to dynamically pad the samples in the batch.
+        **kwargs: Passed on to the `tokenizer.pad` method.
+    """
+
+    def __init__(
+        self,
+        tokenizer: "transformers.PreTrainedTokenizerBase",
+        **kwargs,
+    ):
+        self._tokenizer = tokenizer
+        self._kwargs = {"return_tensors": "pt"}
+        self._kwargs.update(kwargs)
+
+    def train_collate(
+        self, batch: List[Tuple[torch.Tensor, Dict]]
+    ) -> Tuple[torch.Tensor, Dict]:
+        L, inputs = self._collate(
+            L_or_Y=[sample[0] for sample in batch],
+            inputs=[sample[1] for sample in batch],
+        )
+        return L, inputs
+
+    def test_collate(
+        self, batch: List[Tuple[Dict, torch.Tensor]]
+    ) -> Tuple[Dict, torch.Tensor]:
+        Y, inputs = self._collate(
+            L_or_Y=[sample[1] for sample in batch],
+            inputs=[sample[0] for sample in batch],
+        )
+        return inputs, Y
+
+    def _collate(
+        self, L_or_Y: List[torch.Tensor], inputs: List[Dict]
+    ) -> Tuple[torch.Tensor, Dict]:
+        return torch.stack(L_or_Y), self._tokenizer.pad(inputs, **self._kwargs)
+
+
+class TransformersDataModule(AbstractWeaselDataModule):
+    """LightningDataModule for the Transformers downstream model.
+
+    Args:
+        label_matrix: The weak label matrix.
+        X_train: Outputs of a `transformers.PreTrainedTokenizerBase`.
+        collator: Needed to dynamically pad the input samples.
+        X_test: Outputs of a `transformers.PreTrainedTokenizerBase`.
+        Y_test: Ground truth labels for the test set.
+        X_validation: Outputs of a `transformers.PreTrainedTokenizerBase`.
+        Y_validation: Ground truth labels for the validation set.
+        **kwargs: Passed on to the init of the parent class.
+
+    Examples:
+        Minimal example
+        >>> from transformers import AutoTokenizer
+        >>> tokenizer = AutoTokenizer.from_pretrained("bert-base-uncased")
+        >>> X_train = [tokenizer(text) for text in ["First example", "Second example"]]
+        >>> label_matrix = np.random.randint(-1, 2, (len(X_train), 10))  # mock weak label matrix
+        >>> data_module = TransformersDataModule(
+        ...     label_matrix = label_matrix,
+        ...     X_train = X_train,
+        ...     collator=TransformersCollator(tokenizer),
+        ... )
+
+        Using Hugging Face's datasets
+        >>> from datasets import load_dataset
+        >>> from transformers import AutoTokenizer
+        >>> ds = load_dataset("tweet_eval", "sentiment")
+        >>> tokenizer = AutoTokenizer.from_pretrained("bert-base-uncased")
+        >>> ds_train = ds["train"].map(tokenizer, input_columns="text", remove_columns=ds["train"].column_names)
+        >>> ds_test = ds["test"].map(tokenizer, input_columns="text", remove_columns=ds["test"].column_names)
+        >>> label_matrix = np.random.randint(-1, 4, (len(ds_train), 10))  # mock weak label matrix
+        >>> data_module = TransformersDataModule(
+        ...     label_matrix = label_matrix,
+        ...     X_train = list(ds_train),
+        ...     collator=TransformersCollator(tokenizer),
+        ...     X_test = list(ds_test),
+        ...     Y_test = np.array(ds["test"]["label"])
+        ... )
+    """
+
+    def __init__(
+        self,
+        label_matrix: Union[np.ndarray, torch.Tensor],
+        X_train: List[Dict],
+        collator: TransformersCollator,
+        X_test: Optional[List[Dict]] = None,
+        Y_test: Optional[Union[np.ndarray, torch.Tensor]] = None,
+        X_validation: Optional[List[Dict]] = None,
+        Y_validation: Optional[Union[np.ndarray, torch.Tensor]] = None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+
+        self._train_set = TransformersTrainDataset(L=label_matrix, inputs=X_train)
+        self._collator = collator
+
+        self._test_set = None
+        if X_test is not None and Y_test is not None:
+            self._test_set = TransformersTestDataset(inputs=X_test, Y=Y_test)
+
+        self._val_set = None
+        if X_validation is not None and Y_validation is not None:
+            self._val_set = TransformersTestDataset(inputs=X_validation, Y=Y_validation)
+
+    def get_train_data(self) -> TransformersTrainDataset:
+        return self._train_set
+
+    def get_test_data(self) -> TransformersTestDataset:
+        return self._test_set
+
+    def get_val_data(self) -> TransformersTestDataset:
+        return self._val_set
+
+    def train_dataloader(self):
+        return DataLoader(
+            dataset=self._data_train,
+            batch_size=self.batch_size,
+            num_workers=self.num_workers,
+            pin_memory=self.pin_memory,
+            shuffle=True,
+            collate_fn=self._collator.train_collate,
+        )
+
+    def val_dataloader(self):
+        return DataLoader(
+            dataset=self._data_val,
+            batch_size=self.batch_size,
+            num_workers=self.num_workers,
+            pin_memory=self.pin_memory,
+            shuffle=False,
+            collate_fn=self._collator.test_collate,
+        )
+
+    def test_dataloader(self):
+        return DataLoader(
+            dataset=self._data_test,
+            batch_size=self.batch_size,
+            num_workers=self.num_workers,
+            pin_memory=self.pin_memory,
+            shuffle=False,
+            collate_fn=self._collator.test_collate,
+        )

--- a/weasel/models/downstream_models/transformers.py
+++ b/weasel/models/downstream_models/transformers.py
@@ -23,14 +23,4 @@ class Transformers(DownstreamBaseModel):
         return model_output["logits"]
 
     def get_encoder_features(self, X: Dict, *args, **kwargs) -> Any:
-        """
-        This method returns features that will be used by Weasel's encoder network when Weasel.use_aux_input_for_encoder is True.
-        Usually, they can just be the same features X, though they may (need to) be processed by the network or manually.
-
-        args:
-            X (Any): the same features that are provided to the main model in self.forward(.)
-        Returns:
-            Anything that is usable by the encoder network (usually just the same features/a tensor)
-                as auxiliary input, besides the label matrix. E.g. a (n, d) tensor for a default MLP encoder.
-        """
         return X["input_ids"]

--- a/weasel/models/downstream_models/transformers.py
+++ b/weasel/models/downstream_models/transformers.py
@@ -1,0 +1,36 @@
+from typing import Any, Dict
+
+from transformers import AutoModelForSequenceClassification
+
+from weasel.models.downstream_models.base_model import DownstreamBaseModel
+
+
+class Transformers(DownstreamBaseModel):
+    """A downstream model for sequence classification using the transformers library.
+
+    Args:
+        name: Usually the name of the model on the Hugging Face Model Hub. Passed on to the
+            ``AutoModelForSequenceClassification.from_pretrained`` method.
+        num_labels: Number of labels of your classification task.
+    """
+    def __init__(self, name: str, num_labels: int = 2):
+        super().__init__()
+        self.out_dim = num_labels
+        self.model = AutoModelForSequenceClassification.from_pretrained(name, num_labels=num_labels)
+
+    def forward(self, kwargs):
+        model_output = self.model(**kwargs)
+        return model_output["logits"]
+
+    def get_encoder_features(self, X: Dict, *args, **kwargs) -> Any:
+        """
+        This method returns features that will be used by Weasel's encoder network when Weasel.use_aux_input_for_encoder is True.
+        Usually, they can just be the same features X, though they may (need to) be processed by the network or manually.
+
+        args:
+            X (Any): the same features that are provided to the main model in self.forward(.)
+        Returns:
+            Anything that is usable by the encoder network (usually just the same features/a tensor)
+                as auxiliary input, besides the label matrix. E.g. a (n, d) tensor for a default MLP encoder.
+        """
+        return X["input_ids"]


### PR DESCRIPTION
Hey @salvaRC et al! First of all, thanks for your amazing work and making it publicly available + providing very decent documentation on how to use and extend it :) I think @dvsrepo already spoke to you about our intention to add built-in support for HF transformers model to your amazing project, so here comes the PR.

It is basically based on our [weak supervision guide](https://rubrix.readthedocs.io/en/stable/guides/weak-supervision.html#Joint-Model-with-Weasel), with a few improvements and using a lightning data module. I tested the new implementation with our guide and the results are identical, so it should be working alright. Needless to say, that with this new implementation our guide looks a lot slicker!

Please let me know if you have any questions about the implementation, or if you have ideas/comments on how to improve it. Actually, I am unsure about what to return in the `DownstreamBaseModel.get_encoder_features()` method. For now, I simply return the token IDs, but maybe the embeddings (if possible) would be more helpful for weasel's encoder, even though they change during training. What do you think?
Looking forward to working with you!